### PR TITLE
Remove the "NFT" word from the token names.

### DIFF
--- a/testnet_tokenlist.json
+++ b/testnet_tokenlist.json
@@ -12,7 +12,7 @@
         {
             "token_id": "TWar6LKVSYRwxkEZ3Viqa1QAZeq25w93WmHAbppbf",
             "ticker": "OCTTest",
-            "name": "Testnet NFT Octopus",
+            "name": "Testnet OCT Token",
             "logo": "https://explorer.v.systems/data/Upload/45ad7740e18ab270c3b6fa0bb621b040.png",
             "max_supply": 1000000,
             "unity": 100,

--- a/tokenlist.json
+++ b/tokenlist.json
@@ -21,7 +21,7 @@
         {
             "token_id": "TWar6LKVSYRwxkEZ3Viqa1QAZeq25w93WmHAbppbf",
             "ticker": "OCT",
-            "name": "NFT Octopus",
+            "name": "OCT Token",
             "logo": "https://explorer.v.systems/data/Upload/45ad7740e18ab270c3b6fa0bb621b040.png",
             "max_supply": 30000,
             "unity": 100000000,


### PR DESCRIPTION
The "NFT" part in the token names makes it rather difficult to post some of the products to distributing platforms.